### PR TITLE
WPackagistから取得したthemeとpluginの置き場所を指定

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
         "wpackagist-plugin/akismet": "~4.0"
     },
     "extra": {
-        "wordpress-install-dir": "wp"
+        "wordpress-install-dir": "wp",
+        "installer-paths" : {
+             "wp-content/mu-plugins/{$name}/" : ["type:wordpress-plugin"],
+             "wp-content/themes/{$name}/" : ["type:wordpress-theme"]
+        }
     },
     "scripts": {
         "post-package-install": "Installer::postPackageInstall",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "wordpress-install-dir": "wp",
         "installer-paths" : {
              "wp-content/mu-plugins/{$name}/" : ["type:wordpress-plugin"],
-             "wp-content/themes/{$name}/" : ["type:wordpress-theme"]
+             "wp-content/my-themes/{$name}/" : ["type:wordpress-theme"]
         }
     },
     "scripts": {

--- a/scripts/Installer.php
+++ b/scripts/Installer.php
@@ -67,6 +67,10 @@ class Installer
                 'target' => '../../wp-content/uploads',
                 'link' => "{$wpDir}/wp-content/uploads",
             ),
+            array(
+                'target' => '../../wp-content/mu-plugins',
+                'link' => "{$wpDir}/wp-content/mu-plugins",
+            ),
         );
 
         $isWin = DIRECTORY_SEPARATOR !== '/';

--- a/wp-content/mu-plugins/wpackagist-plugin-loader.php
+++ b/wp-content/mu-plugins/wpackagist-plugin-loader.php
@@ -1,0 +1,7 @@
+<?php
+
+exec('grep -l "Plugin Name" ' . WPMU_PLUGIN_DIR . '/*/*.php', $stdout, $status);
+
+foreach($stdout as $file){
+	require_once $file;
+}


### PR DESCRIPTION
### wpackagist-plugin

`wp-content/mu-plugins` 配下に設置する
WordPressで読み込むのは `wp-content/mu-plugins/wp-packagist-plugin-loader.php` に任せる

### wpackagist-theme

`wp-content/my-theme` 配下に設置する
 WordPress管理画面から追加したテーマは `wp/wp-content/theme` 配下に置かれる